### PR TITLE
feat(extension): enable night light on move slider, fixes #12

### DIFF
--- a/night-light-slider.timur@linux.com/extension.js
+++ b/night-light-slider.timur@linux.com/extension.js
@@ -77,6 +77,8 @@ const SliderMenuItem = new Lang.Class({
   _sliderChanged: function (slider, value) {
     const temperature = (value * (this._max - this._min)) + this._min
     this._schema.set_uint('night-light-temperature', parseInt(temperature))
+    // If slider is moved, enable night light
+    this._schema.set_boolean('night-light-enabled', true)
   },
   update_view: function () {
     // Update temperature view


### PR DESCRIPTION
This fixes #12 by enabling the night light on moving the slider. There seems to be no apparent performance degradation in doing so.