### PR TITLE
[WIP] feat(extension): i18n support

### DIFF
--- a/night-light-slider.timur@linux.com/convenience.js
+++ b/night-light-slider.timur@linux.com/convenience.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-vars */
 /* global imports log */
 const Gio = imports.gi.Gio
-const Gettext = imports.gettext
 const Me = imports.misc.extensionUtils.getCurrentExtension()
 
 function getSettings () {
@@ -19,9 +18,4 @@ function getSettings () {
   }
 
   return new Gio.Settings({ settings_schema: settingsSchema })
-}
-
-function initTranslations (extension) {
-  const localeDir = extension.dir.get_child('locale').get_path()
-  Gettext.bindtextdomain('night-light-slider', localeDir)
 }

--- a/night-light-slider.timur@linux.com/convenience.js
+++ b/night-light-slider.timur@linux.com/convenience.js
@@ -1,8 +1,10 @@
+/* eslint-disable no-unused-vars */
 /* global imports log */
 const Gio = imports.gi.Gio
+const Gettext = imports.gettext
 const Me = imports.misc.extensionUtils.getCurrentExtension()
 
-function getSettings () { // eslint-disable-line no-unused-vars
+function getSettings () {
   const schema = Me.metadata['settings-schema']
   const schemaDir = Me.dir.get_child('schemas')
 
@@ -17,4 +19,9 @@ function getSettings () { // eslint-disable-line no-unused-vars
   }
 
   return new Gio.Settings({ settings_schema: settingsSchema })
+}
+
+function initTranslations (extension) {
+  const localeDir = extension.dir.get_child('locale').get_path()
+  Gettext.bindtextdomain('night-light-slider', localeDir)
 }

--- a/night-light-slider.timur@linux.com/extension.js
+++ b/night-light-slider.timur@linux.com/extension.js
@@ -241,5 +241,6 @@ const NightLightExtension = new Lang.Class({
 })
 
 function init () { // eslint-disable-line
+  Convenience.initTranslations(Me)
   return new NightLightExtension()
 }

--- a/night-light-slider.timur@linux.com/extension.js
+++ b/night-light-slider.timur@linux.com/extension.js
@@ -241,6 +241,5 @@ const NightLightExtension = new Lang.Class({
 })
 
 function init () { // eslint-disable-line
-  Convenience.initTranslations(Me)
   return new NightLightExtension()
 }

--- a/night-light-slider.timur@linux.com/lang.js
+++ b/night-light-slider.timur@linux.com/lang.js
@@ -1,0 +1,35 @@
+/* eslint-disable no-unused-vars */
+
+const preferences = {
+  showAlways: {
+    label: 'Show always',
+    tooltip: 'Show slider even when night light is off'
+  },
+  showStatusIcon: {
+    label: 'Show status icon',
+    tooltip: 'Show status icon in status area'
+  },
+  enableAlways: {
+    label: 'Enable always',
+    tooltip: 'Enable night light throughout the day'
+  },
+  brightnessSync: {
+    label: 'Brightness sync',
+    tooltip: 'Sync brightness slider with night light slider'
+  },
+  showInSubmenu: {
+    label: 'Show in submenu',
+    tooltip: 'Display slider in night light submenu'
+  },
+  minimum: {
+    label: 'Minimum value',
+    tooltip: 'Minimum night light slider value'
+  },
+  maximum: {
+    label: 'Maximum value',
+    tooltip: 'Maximum night light slider value'
+  },
+  restartRequired: {
+    label: 'Changes require restarting shell (logging in and out) to take place.'
+  }
+}

--- a/night-light-slider.timur@linux.com/lang.js
+++ b/night-light-slider.timur@linux.com/lang.js
@@ -1,35 +1,39 @@
 /* eslint-disable no-unused-vars */
+/* global imports */
+
+const Gettext = imports.gettext
+const { gettext: _ } = Gettext.domain('night-light-slider')
 
 const preferences = {
   showAlways: {
-    label: 'Show always',
-    tooltip: 'Show slider even when night light is off'
+    label: _('Show always'),
+    tooltip: _('Show slider even when night light is off')
   },
   showStatusIcon: {
-    label: 'Show status icon',
-    tooltip: 'Show status icon in status area'
+    label: _('Show status icon'),
+    tooltip: _('Show status icon in status area')
   },
   enableAlways: {
-    label: 'Enable always',
-    tooltip: 'Enable night light throughout the day'
+    label: _('Enable always'),
+    tooltip: _('Enable night light throughout the day')
   },
   brightnessSync: {
-    label: 'Brightness sync',
-    tooltip: 'Sync brightness slider with night light slider'
+    label: _('Brightness sync'),
+    tooltip: _('Sync brightness slider with night light slider')
   },
   showInSubmenu: {
-    label: 'Show in submenu',
-    tooltip: 'Display slider in night light submenu'
+    label: _('Show in submenu'),
+    tooltip: _('Display slider in night light submenu')
   },
   minimum: {
-    label: 'Minimum value',
-    tooltip: 'Minimum night light slider value'
+    label: _('Minimum value'),
+    tooltip: _('Minimum night light slider value')
   },
   maximum: {
-    label: 'Maximum value',
-    tooltip: 'Maximum night light slider value'
+    label: _('Maximum value'),
+    tooltip: _('Maximum night light slider value')
   },
   restartRequired: {
-    label: 'Changes require restarting shell (logging in and out) to take place.'
+    label: _('Changes require restarting shell (logging in and out) to take place.')
   }
 }

--- a/night-light-slider.timur@linux.com/lang.js
+++ b/night-light-slider.timur@linux.com/lang.js
@@ -2,6 +2,15 @@
 /* global imports */
 
 const Gettext = imports.gettext
+const Me = imports.misc.extensionUtils.getCurrentExtension()
+
+;(function () {
+  // Initialize gettext
+  const localeDir = Me.dir.get_child('locale').get_path()
+  Gettext.bindtextdomain('night-light-slider', localeDir)
+})()
+
+// Assign gettext as _
 const { gettext: _ } = Gettext.domain('night-light-slider')
 
 const preferences = {

--- a/night-light-slider.timur@linux.com/night-light-slider.pot
+++ b/night-light-slider.timur@linux.com/night-light-slider.pot
@@ -1,0 +1,72 @@
+# gnome-shell-night-light-slider translation file
+# Copyright (C) 2019
+# This file is distributed under the GPLv2+
+# Timur Kiyui <timur@linux.com>, 2017-2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2019-01-09 23:37+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: \n"
+
+#: lang.js:9
+msgid "Show always"
+msgstr ""
+
+#: lang.js:10
+msgid "Show slider even when night light is off"
+msgstr ""
+
+#: lang.js:13
+msgid "Show status icon"
+msgstr ""
+
+#: lang.js:14
+msgid "Show status icon in status area"
+msgstr ""
+
+#: lang.js:17
+msgid "Enable always"
+msgstr ""
+
+#: lang.js:18
+msgid "Enable night light throughout the day"
+msgstr ""
+
+#: lang.js:21
+msgid "Brightness sync"
+msgstr ""
+
+#: lang.js:22
+msgid "Sync brightness slider with night light slider"
+msgstr ""
+
+#: lang.js:25
+msgid "Show in submenu"
+msgstr ""
+
+#: lang.js:26
+msgid "Display slider in night light submenu"
+msgstr ""
+
+#: lang.js:29
+msgid "Minimum value"
+msgstr ""
+
+#: lang.js:30
+msgid "Minimum night light slider value"
+msgstr ""
+
+#: lang.js:33
+msgid "Maximum value"
+msgstr ""
+
+#: lang.js:34
+msgid "Maximum night light slider value"
+msgstr ""
+
+#: lang.js:37
+msgid "Changes require restarting shell (logging in and out) to take place."
+msgstr ""

--- a/night-light-slider.timur@linux.com/prefs.js
+++ b/night-light-slider.timur@linux.com/prefs.js
@@ -4,41 +4,25 @@ const Gtk = imports.gi.Gtk
 
 // Extension specific
 const Me = imports.misc.extensionUtils.getCurrentExtension()
+const Lang = Me.imports.lang
 const Convenience = Me.imports.convenience
 
 function buildPrefsWidget () { // eslint-disable-line no-unused-vars
   const schema = Convenience.getSettings()
 
-  // Text and descriptions
-  const showAlwaysName = 'Show always'
-  const showAlwaysDescription = 'Show slider even when night light is off'
-  const showIconName = 'Show status icon'
-  const showIconDescription = 'Show status icon in status area'
-  const enableAlwaysName = 'Enable always'
-  const enableAlwaysDescription = 'Enable night light throughout the day'
-  const minimumName = 'Minimum value'
-  const minimumDescription = 'Minimum night light slider value'
-  const maximumName = 'Maximum value'
-  const maximumDescription = 'Maximum night light slider value'
-  const brightnessSyncName = 'Brightness sync'
-  const brightnessSyncDescription = 'Sync brightness slider with night light slider'
-  const showInSubmenuName = 'Show in submenu'
-  const showInSubmenuDescription = 'Display slider in night light submenu'
-  const restartRequiredName = 'Changes require restarting shell (logging in and out) to take place.'
-
   // Create children objects
   const widgets = [
     {
       type: 'Label',
-      params: { label: `${showAlwaysName}: ` },
-      tooltip: showAlwaysDescription,
+      params: { label: `${Lang.preferences.showAlways.label}: ` },
+      tooltip: Lang.preferences.showAlways.tooltip,
       align: Gtk.Align.END,
       attach: [0, 1, 1, 1]
     },
     {
       type: 'Switch',
       params: { active: schema.get_boolean('show-always') },
-      tooltip: showAlwaysDescription,
+      tooltip: Lang.preferences.showAlways.tooltip,
       align: Gtk.Align.START,
       attach: [1, 1, 1, 1],
       connect: {
@@ -49,15 +33,15 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
     },
     {
       type: 'Label',
-      params: { label: `${showIconName}: ` },
-      tooltip: showIconDescription,
+      params: { label: `${Lang.preferences.showStatusIcon.label}: ` },
+      tooltip: Lang.preferences.showStatusIcon.tooltip,
       align: Gtk.Align.END,
       attach: [0, 2, 1, 1]
     },
     {
       type: 'Switch',
       params: { active: schema.get_boolean('show-status-icon') },
-      tooltip: showIconDescription,
+      tooltip: Lang.preferences.showStatusIcon.tooltip,
       align: Gtk.Align.START,
       attach: [1, 2, 1, 1],
       connect: {
@@ -68,15 +52,15 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
     },
     {
       type: 'Label',
-      params: { label: `${enableAlwaysName}: ` },
-      tooltip: enableAlwaysDescription,
+      params: { label: `${Lang.preferences.enableAlways.label}: ` },
+      tooltip: Lang.preferences.enableAlways.tooltip,
       align: Gtk.Align.END,
       attach: [0, 3, 1, 1]
     },
     {
       type: 'Switch',
       params: { active: schema.get_boolean('enable-always') },
-      tooltip: enableAlwaysDescription,
+      tooltip: Lang.preferences.enableAlways.tooltip,
       align: Gtk.Align.START,
       attach: [1, 3, 1, 1],
       connect: {
@@ -87,15 +71,15 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
     },
     {
       type: 'Label',
-      params: { label: `${brightnessSyncName}: ` },
-      tooltip: brightnessSyncDescription,
+      params: { label: `${Lang.preferences.brightnessSync.label}: ` },
+      tooltip: Lang.preferences.brightnessSync.tooltip,
       align: Gtk.Align.END,
       attach: [0, 4, 1, 1]
     },
     {
       type: 'Switch',
       params: { active: schema.get_boolean('brightness-sync') },
-      tooltip: brightnessSyncDescription,
+      tooltip: Lang.preferences.brightnessSync.tooltip,
       align: Gtk.Align.START,
       attach: [1, 4, 1, 1],
       connect: {
@@ -106,15 +90,15 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
     },
     {
       type: 'Label',
-      params: { label: `${showInSubmenuName}: ` },
-      tooltip: showInSubmenuDescription,
+      params: { label: `${Lang.preferences.showInSubmenu.label}: ` },
+      tooltip: Lang.preferences.showInSubmenu.tooltip,
       align: Gtk.Align.END,
       attach: [0, 5, 1, 1]
     },
     {
       type: 'Switch',
       params: { active: schema.get_boolean('show-in-submenu') },
-      tooltip: showInSubmenuDescription,
+      tooltip: Lang.preferences.showInSubmenu.tooltip,
       align: Gtk.Align.START,
       attach: [1, 5, 1, 1],
       connect: {
@@ -125,15 +109,15 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
     },
     {
       type: 'Label',
-      params: { label: `${minimumName}: ` },
-      tooltip: minimumDescription,
+      params: { label: `${Lang.preferences.minimum.label}: ` },
+      tooltip: Lang.preferences.minimum.tooltip,
       align: Gtk.Align.END,
       attach: [0, 6, 1, 1]
     },
     {
       type: 'Entry',
       params: { text: schema.get_int('minimum').toString() },
-      tooltip: minimumDescription,
+      tooltip: Lang.preferences.minimum.tooltip,
       align: Gtk.Align.START,
       attach: [1, 6, 1, 1],
       connect: {
@@ -144,15 +128,15 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
     },
     {
       type: 'Label',
-      params: { label: `${maximumName}: ` },
-      tooltip: maximumDescription,
+      params: { label: `${Lang.preferences.maximum.label}: ` },
+      tooltip: Lang.preferences.maximum.tooltip,
       align: Gtk.Align.END,
       attach: [0, 7, 1, 1]
     },
     {
       type: 'Entry',
       params: { text: schema.get_int('maximum').toString() },
-      tooltip: maximumDescription,
+      tooltip: Lang.preferences.maximum.tooltip,
       align: Gtk.Align.START,
       attach: [1, 7, 1, 1],
       connect: {
@@ -163,7 +147,7 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
     },
     {
       type: 'Label',
-      params: { label: restartRequiredName },
+      params: { label: Lang.preferences.restartRequired.label },
       align: Gtk.Align.CENTER,
       attach: [0, 8, 2, 1]
     }

--- a/night-light-slider.timur@linux.com/prefs.js
+++ b/night-light-slider.timur@linux.com/prefs.js
@@ -188,6 +188,5 @@ function buildPrefsWidget () {
 }
 
 function init () {
-  Convenience.initTranslations(Me)
   log('Setting up night light slider preferences')
 }

--- a/night-light-slider.timur@linux.com/prefs.js
+++ b/night-light-slider.timur@linux.com/prefs.js
@@ -10,20 +10,21 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
   const schema = Convenience.getSettings()
 
   // Text and descriptions
-  const showAlwaysName = schema.settings_schema.get_key('show-always').get_summary()
-  const showAlwaysDescription = schema.settings_schema.get_key('show-always').get_description()
-  const showIconName = schema.settings_schema.get_key('show-status-icon').get_summary()
-  const showIconDescription = schema.settings_schema.get_key('show-status-icon').get_description()
-  const enableAlwaysName = schema.settings_schema.get_key('enable-always').get_summary()
-  const enableAlwaysDescription = schema.settings_schema.get_key('enable-always').get_description()
-  const minimumName = schema.settings_schema.get_key('minimum').get_summary()
-  const minimumDescription = schema.settings_schema.get_key('minimum').get_description()
-  const maximumName = schema.settings_schema.get_key('maximum').get_summary()
-  const maximumDescription = schema.settings_schema.get_key('maximum').get_description()
-  const brightnessSyncName = schema.settings_schema.get_key('brightness-sync').get_summary()
-  const brightnessSyncDescription = schema.settings_schema.get_key('brightness-sync').get_description()
-  const showInSubmenuName = schema.settings_schema.get_key('show-in-submenu').get_summary()
-  const showInSubmenuDescription = schema.settings_schema.get_key('show-in-submenu').get_description()
+  const showAlwaysName = 'Show always'
+  const showAlwaysDescription = 'Show slider even when night light is off'
+  const showIconName = 'Show status icon'
+  const showIconDescription = 'Show status icon in status area'
+  const enableAlwaysName = 'Enable always'
+  const enableAlwaysDescription = 'Enable night light throughout the day'
+  const minimumName = 'Minimum value'
+  const minimumDescription = 'Minimum night light slider value'
+  const maximumName = 'Maximum value'
+  const maximumDescription = 'Maximum night light slider value'
+  const brightnessSyncName = 'Brightness sync'
+  const brightnessSyncDescription = 'Sync brightness slider with night light slider'
+  const showInSubmenuName = 'Show in submenu'
+  const showInSubmenuDescription = 'Display slider in night light submenu'
+  const restartRequiredName = 'Changes require restarting shell (logging in and out) to take place.'
 
   // Create children objects
   const widgets = [
@@ -49,7 +50,7 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
     {
       type: 'Label',
       params: { label: `${showIconName}: ` },
-      tooltip: showAlwaysDescription,
+      tooltip: showIconDescription,
       align: Gtk.Align.END,
       attach: [0, 2, 1, 1]
     },
@@ -162,8 +163,7 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
     },
     {
       type: 'Label',
-      params: { label: 'Changes require restarting shell (logging in and out) to take place.' },
-      tooltip: showAlwaysDescription,
+      params: { label: restartRequiredName },
       align: Gtk.Align.CENTER,
       attach: [0, 8, 2, 1]
     }
@@ -179,8 +179,10 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
   widgets.map(function createWidget ({ type, params, tooltip, align, attach, connect }) {
     const widget = new Gtk[type](params)
 
-    // Set description
-    widget.set_tooltip_text(tooltip)
+    if (tooltip) {
+      // Set description
+      widget.set_tooltip_text(tooltip)
+    }
 
     // Set alignment
     widget.set_halign(align)

--- a/night-light-slider.timur@linux.com/prefs.js
+++ b/night-light-slider.timur@linux.com/prefs.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /* global imports log */
 
 const Gtk = imports.gi.Gtk
@@ -7,7 +8,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension()
 const Lang = Me.imports.lang
 const Convenience = Me.imports.convenience
 
-function buildPrefsWidget () { // eslint-disable-line no-unused-vars
+function buildPrefsWidget () {
   const schema = Convenience.getSettings()
 
   // Create children objects
@@ -186,6 +187,7 @@ function buildPrefsWidget () { // eslint-disable-line no-unused-vars
   return vbox
 }
 
-function init () { // eslint-disable-line
+function init () {
+  Convenience.initTranslations(Me)
   log('Setting up night light slider preferences')
 }

--- a/night-light-slider.timur@linux.com/schemas/org.gnome.shell.extensions.nightlightslider.gschema.xml
+++ b/night-light-slider.timur@linux.com/schemas/org.gnome.shell.extensions.nightlightslider.gschema.xml
@@ -2,38 +2,24 @@
     <schema id="org.gnome.shell.extensions.nightlightslider" path="/org/gnome/shell/extensions/nightlightslider/">
         <key name="show-always" type="b">
             <default>false</default>
-            <summary>Show always</summary>
-            <description>Show slider even when night light is off</description>
         </key>
         <key name="show-status-icon" type="b">
             <default>true</default>
-            <summary>Show status icon</summary>
-            <description>Show status icon in status area</description>
         </key>
         <key name="enable-always" type="b">
             <default>false</default>
-            <summary>Enable always</summary>
-            <description>Enable night light throughout the day</description>
         </key>
         <key name="minimum" type="i">
             <default>2500</default>
-            <summary>Minimum value</summary>
-            <description>Minimum night light slider value</description>
         </key>
         <key name="maximum" type="i">
             <default>6500</default>
-            <summary>Maximum value</summary>
-            <description>Maximum night light slider value</description>
         </key>
         <key name="brightness-sync" type="b">
             <default>false</default>
-            <summary>Brightness sync</summary>
-            <description>Sync brightness slider with night light slider</description>
         </key>
         <key name="show-in-submenu" type="b">
             <default>false</default>
-            <summary>Show in submenu</summary>
-            <description>Display slider in night light submenu</description>
         </key>
     </schema>
 </schemalist>


### PR DESCRIPTION
This should address the concerns in #34.

Changes:
- [x] Did some code refactor such that all strings are centralized
- [x] Added a `.pot` file with all the strings
- [ ] Add some languages for testing and initial release
- [ ] Add build script so `.mo` files do not need to be included (add to `package.json` or introduce `meson`)

Contributing:
Where `$lang` is a language such as `en_US`, do the following in the extension directory:
- `mkdir -p locale/$lang/LC_MESSAGES`
- `msginit -i night-light-slider.pot -o locale/$lang/LC_MESSAGES/night-light-slider.po`
- Modify `locale/$lang/LC_MESSAGES/night-light-slider.po` with your locale
- `msgfmt locale/$lang/LC_MESSAGES/night-light-slider.po -o locale/$lang/LC_MESSAGES/night-light-slider.mo`
- Submit a PR without the compiled `.mo` files