### PR TITLE
chore: update defaults for 3.34

### DIFF
--- a/night-light-slider.timur@linux.com/schemas/org.gnome.shell.extensions.nightlightslider.gschema.xml
+++ b/night-light-slider.timur@linux.com/schemas/org.gnome.shell.extensions.nightlightslider.gschema.xml
@@ -16,12 +16,12 @@
             <description>Enable night light throughout the day</description>
         </key>
         <key name="minimum" type="i">
-            <default>2500</default>
+            <default>1500</default>
             <summary>Minimum value</summary>
             <description>Minimum night light slider value</description>
         </key>
         <key name="maximum" type="i">
-            <default>6500</default>
+            <default>5000</default>
             <summary>Maximum value</summary>
             <description>Maximum night light slider value</description>
         </key>


### PR DESCRIPTION
This fixes an issue with the changes in sensitivity for 3.34

**Changes made:**
- Made minimum default `1500`
- Made maximum default `5000`
