### PR TITLE
refactor(extension): this fixes #57, adds 3.36 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ Manage GNOME's built-in night light temperature intensity from the panel
 Available from GNOME extensions website [here](https://extensions.gnome.org/extension/1276/night-light-slider/), make sure to enable Night Light under Settings/Display
 
 ## contributors
-- [@protopopov1122](https://github.com/protopopov1122) [#46](https://github.com/TimurKiyivinski/gnome-shell-night-light-slider-extension/pull/46)
+- [@protopopov1122](https://github.com/protopopov1122) [#46](https://github.com/kiyui/gnome-shell-night-light-slider-extension/pull/46) [#49](https://github.com/kiyui/gnome-shell-night-light-slider-extension/pull/49)
+- [@themightydeity](https://github.com/themightydeity) [#58](https://github.com/kiyui/gnome-shell-night-light-slider-extension/pull/58)

--- a/night-light-slider.timur@linux.com/extension.js
+++ b/night-light-slider.timur@linux.com/extension.js
@@ -25,74 +25,74 @@ const ColorInterface = '<node> \
 </node>'
 /* eslint-enable */
 
-const NightLightSlider = GObject.registerClass(
-  {
-    GType: 'NightLightSlider'
-  }, class NightLightSlider extends PanelMenu.SystemIndicator {
-    _init(schema, settings) {
-      super._init('night-light-symbolic')
-      this._schema = schema
-      this._min = settings.minimum
-      this._max = settings.maximum
-      this._listeners = []
+const NightLightSlider = GObject.registerClass({
+  GType: 'NightLightSlider'
+},
+class NightLightSlider extends PanelMenu.SystemIndicator {
+  _init (schema, settings) {
+    super._init('night-light-symbolic')
+    this._schema = schema
+    this._min = settings.minimum
+    this._max = settings.maximum
+    this._listeners = []
 
-      // Set up view
-      this._item = new PopupMenu.PopupBaseMenuItem({ activate: false })
-      this.menu.addMenuItem(this._item)
+    // Set up view
+    this._item = new PopupMenu.PopupBaseMenuItem({ activate: false })
+    this.menu.addMenuItem(this._item)
 
-      if (settings.enable_icon) {
-        this._icon = new St.Icon({ icon_name: 'night-light-symbolic', style_class: 'popup-menu-icon' })
-        this._item.actor.add(this._icon)
-      }
-
-      // Slider
-      this._slider = new Slider.Slider(0)
-      this._slider.connect('notify::value', this._sliderChanged.bind(this))
-      this._slider.actor.accessible_name = 'Temperature'
-      this._item.actor.add(this._slider.actor, { expand: true })
-
-      // Connect events
-      this._item.actor.connect('button-press-event',
-        (actor, event) => this._slider.startDragging(event))
-      this._item.actor.connect('key-press-event',
-        (actor, event) => this._slider.onKeyPressEvent(actor, event))
-
-      // Update initial view
-      this._updateView()
+    if (settings.enable_icon) {
+      this._icon = new St.Icon({ icon_name: 'night-light-symbolic', style_class: 'popup-menu-icon' })
+      this._item.actor.add(this._icon)
     }
 
-    _proxyHandler (proxy, error) {
-      if (error) {
-        log(error.message)
-        return
-      }
-      this.proxy.connect('g-properties-changed', this.update_view.bind(this))
-    }
+    // Slider
+    this._slider = new Slider.Slider(0)
+    this._slider.connect('notify::value', this._sliderChanged.bind(this))
+    this._slider.actor.accessible_name = 'Temperature'
+    this._item.actor.add(this._slider.actor, { expand: true })
 
-    _sliderChanged (slider) {
-      const temperature = parseInt(this._slider.value * (this._max - this._min)) + this._min
-      this._schema.set_uint('night-light-temperature', temperature)
+    // Connect events
+    this._item.actor.connect('button-press-event',
+      (actor, event) => this._slider.startDragging(event))
+    this._item.actor.connect('key-press-event',
+      (actor, event) => this._slider.onKeyPressEvent(actor, event))
 
-      this._listeners.forEach(callback => {
-        callback(temperature, this._slider.value)
-      })
-    }
+    // Update initial view
+    this._updateView()
+  }
 
-    _onSliderChanged (callback) {
-      this._listeners.push(callback)
+  _proxyHandler (proxy, error) {
+    if (error) {
+      log(error.message)
+      return
     }
+    this.proxy.connect('g-properties-changed', this.update_view.bind(this))
+  }
 
-    _updateView () {
-      // Update temperature view
-      const temperature = this._schema.get_uint('night-light-temperature')
-      const value = (temperature - this._min) / (this._max - this._min)
-      this._slider.value = value
-    }
+  _sliderChanged (slider) {
+    const temperature = parseInt(this._slider.value * (this._max - this._min)) + this._min
+    this._schema.set_uint('night-light-temperature', temperature)
 
-    _scroll (event) {
-      this._slider.scroll(event)
-    }
-  })
+    this._listeners.forEach(callback => {
+      callback(temperature, this._slider.value)
+    })
+  }
+
+  _onSliderChanged (callback) {
+    this._listeners.push(callback)
+  }
+
+  _updateView () {
+    // Update temperature view
+    const temperature = this._schema.get_uint('night-light-temperature')
+    const value = (temperature - this._min) / (this._max - this._min)
+    this._slider.value = value
+  }
+
+  _scroll (event) {
+    this._slider.scroll(event)
+  }
+})
 
 class NightLightSchedule {
   constructor (schema) {

--- a/night-light-slider.timur@linux.com/metadata.json
+++ b/night-light-slider.timur@linux.com/metadata.json
@@ -3,9 +3,9 @@
   "description": "Change night light temperature",
   "settings-schema": "org.gnome.shell.extensions.nightlightslider",
   "uuid": "night-light-slider.timur@linux.com",
-  "version": 13,
+  "version": 14,
   "url": "https://github.com/kiyui/gnome-shell-night-light-slider-extension",
   "shell-version": [
-    "3.34"
+    "3.36"
   ]
 }


### PR DESCRIPTION
This fixes some breaking changes with how GNOME 3.36 registers classes:
http://gjs.guide/guides/gjs/transition.html

**Changes made:**
- Wrap the class in GObject
- Change the `contructor` to `_init`

**Thanks:**
Special thanks to @themightydeity for the pointer in #58