### PR TITLE
fix(deprecation warnings): update deprecated calls

### DIFF
--- a/night-light-slider.timur@linux.com/extension.js
+++ b/night-light-slider.timur@linux.com/extension.js
@@ -47,20 +47,20 @@ const NightLightSlider = GObject.registerClass(
           icon_name: "night-light-symbolic",
           style_class: "popup-menu-icon",
         });
-        this._item.actor.add(this._icon);
+        this._item.add(this._icon);
       }
 
       // Slider
       this._slider = new Slider.Slider(0);
       this._slider.connect("notify::value", this._sliderChanged.bind(this));
-      this._slider.actor.accessible_name = "Temperature";
-      this._item.actor.add(this._slider.actor, { expand: true });
+      this._slider.accessible_name = "Temperature";
+      this._item.add(this._slider, { expand: true });
 
       // Connect events
-      this._item.actor.connect("button-press-event", (actor, event) =>
+      this._item.connect("button-press-event", (o, event) =>
         this._slider.startDragging(event)
       );
-      this._item.actor.connect("key-press-event", (actor, event) =>
+      this._item.connect("key-press-event", (o, event) =>
         this._slider.onKeyPressEvent(actor, event)
       );
 
@@ -219,7 +219,7 @@ class NightLightExtension {
     }
 
     // When scrolling the indicator, change night light intensity
-    this._icon.indicators.connect("scroll-event", (actor, event) => {
+    this._icon.connect("scroll-event", (o, event) => {
       this._indicator._scroll(event);
       return true;
     });

--- a/night-light-slider.timur@linux.com/extension.js
+++ b/night-light-slider.timur@linux.com/extension.js
@@ -161,9 +161,7 @@ class NightLightExtension {
 
     // Night light icon
     this._icon = Main.panel.statusArea.aggregateMenu._nightLight;
-    // This will be defined if icon is set to hide
     this._indicator = null;
-    this._indicators = null;
     this._construct = () =>
       new Error("[night-light-slider] View construct stub not set up!");
     this._deconstruct = () =>
@@ -213,9 +211,12 @@ class NightLightExtension {
     // Hide status icon if set to disable
     if (!settings.get_boolean("show-status-icon") && this._icon) {
       log(`[night-light-slider] Hiding status icon`);
-      this._indicators = this._icon.indicators;
-      this._icon.indicators.hide();
-      this._icon.indicators = new St.BoxLayout();
+      this._icon.hide();
+
+      // TODO: Rewrite the extension
+      this._hackyShowCallback = this._icon.connect("show", () => {
+        this._icon.hide();
+      });
     }
 
     // When scrolling the indicator, change night light intensity
@@ -261,15 +262,14 @@ class NightLightExtension {
   }
 
   disable() {
+    // TODO: Figure out the proper way to disconnect signals
+    if (this._hackyShowCallback) {
+      this._icon.disconnect(this._hackyShowCallback);
+      this._icon.show();
+    }
+
     // Run deconstruct function
     this._deconstruct();
-
-    // Restore default status icon behaviour
-    if (this._indicators) {
-      Main.panel.statusArea.aggregateMenu._nightLight.indicators.destroy();
-      Main.panel.statusArea.aggregateMenu._nightLight.indicators = this._indicators;
-      Main.panel.statusArea.aggregateMenu._nightLight.indicators.show();
-    }
 
     // Disable updater loop
     this._scheduleUpdater._disableLoop();

--- a/night-light-slider.timur@linux.com/metadata.json
+++ b/night-light-slider.timur@linux.com/metadata.json
@@ -3,7 +3,7 @@
   "description": "Change night light temperature",
   "settings-schema": "org.gnome.shell.extensions.nightlightslider",
   "uuid": "night-light-slider.timur@linux.com",
-  "version": 14,
+  "version": 15,
   "url": "https://github.com/kiyui/gnome-shell-night-light-slider-extension",
   "shell-version": ["3.36"]
 }


### PR DESCRIPTION
This fixes the deprecation warnings shown in #60 :smile: 

**Changes made:**
- Stop using actor property
- Refactored the icon hide functionality to rely on signals instead
- Slight style change from `(actor, event) => { ... }` to `(o, event) => { ... }` after having seen it in some `gnome-shell` code
